### PR TITLE
make the cancel_flag a public attribute of the process client so that…

### DIFF
--- a/server/zoom/agent/client/process_client.py
+++ b/server/zoom/agent/client/process_client.py
@@ -42,7 +42,7 @@ class ProcessClient(object):
         self._script = script
         self._apptype = apptype
         self.restart_logic = restart_logic
-        self._cancel_flag = cancel_flag
+        self.cancel_flag = cancel_flag
 
         self.last_status = False
         self._graphite_metric_names = graphite_metric_names
@@ -290,11 +290,11 @@ class ProcessClient(object):
                         'Returning with 0'.format(cmd))
                     return_code = 0
                     break
-                elif self._cancel_flag == True:
+                elif self.cancel_flag == True:
                     p.terminate()
                     return_code = -2
                     self._log.info('Command {0} was cancelled.'.format(cmd))
-                    self._cancel_flag.set_value(False)
+                    self.cancel_flag.set_value(False)
                     break
                 sleep(1)
 

--- a/server/zoom/agent/client/task_client.py
+++ b/server/zoom/agent/client/task_client.py
@@ -37,7 +37,7 @@ class TaskClient(object):
                 task = Task.from_json(data)
                 self._log.info('Found work to do: {0}'.format(task))
                 if task.result == ApplicationState.OK:
-                    self._log.info('Task is already complete: {0}'.format(task))
+                    self._log.debug('Task is already complete: {0}'.format(task))
                     return  # ignore tasks that are already done
 
                 if task.name in SENTINEL_METHODS:

--- a/server/zoom/agent/entities/child_process.py
+++ b/server/zoom/agent/entities/child_process.py
@@ -43,9 +43,15 @@ class ChildProcess(object):
         """
         Set the cancel flag that is used in the process client.
         """
+        # this seems like a hack. There must be a better way of cancelling while
+        #   still allowing the agent to report up/down status
+        DONT_REMOVE = ('register', 'unregister')
         self._log.info('Setting Cancel Flag and clearing queue.')
         self._cancel_flag.set_value(True)
-        self._action_queue.clear()
+        for i in list(self._action_queue):
+            if i.name not in DONT_REMOVE:
+                self._action_queue.remove(i)
+                self._log.info('Removing task {0}'.format(i))
 
     def stop(self):
         """

--- a/server/zoom/agent/predicate/process.py
+++ b/server/zoom/agent/predicate/process.py
@@ -63,7 +63,10 @@ class PredicateProcess(SimplePredicate):
 
     def _run_loop(self):
         while self._operate == True:
-            self.set_met(self.running())
+            if self._proc_client.cancel_flag == False:
+                self.set_met(self.running())
+            else:
+                self._log.info('Cancel Flag detected, skipping status check.')
             sleep(self.interval)
         self._log.info('Done watching process.')
 


### PR DESCRIPTION
… the process client can skip processing if the flag is set

rather than remove ALL tasks from the task queue, remove all but register/unregister