### PR TITLE
Bugfix/new nodes zkhgc

### DIFF
--- a/server/zoom/agent/predicate/zkhas_children.py
+++ b/server/zoom/agent/predicate/zkhas_children.py
@@ -7,13 +7,20 @@ from zoom.common.decorators import connected
 
 class ZookeeperHasChildren(SimplePredicate):
     def __init__(self, comp_name, zkclient, nodepath, ephemeral_only=True,
-                 met_on_delete=False, operational=False, parent=None):
+                 met_on_delete=False, operational=False, new_node_callback=None,
+                 parent=None):
         """
         :type comp_name: str
         :type zkclient: kazoo.client.KazooClient
         :type nodepath: str
+        :type ephemeral_only: bool
         :type met_on_delete: bool
+        :param met_on_delete: Whether we want met to be True when nodepath is
+                deleted
         :type operational: bool
+        :type new_node_callback: types.FunctionType or None
+        :param new_node_callback: This is a special callback used by
+                ZookeeperHasGranchildren to keep track of new static nodes
         :type parent: str or None
         """
         SimplePredicate.__init__(self, comp_name, operational=operational, parent=parent)
@@ -21,6 +28,7 @@ class ZookeeperHasChildren(SimplePredicate):
         self.zkclient = zkclient
         self._ephemeral_only = ephemeral_only
         self._met_on_delete = met_on_delete
+        self._nn_calback = new_node_callback  # currently unused
         self._log = logging.getLogger('sent.{0}.pred.hc'.format(comp_name))
         self._log.info('Registered {0}'.format(self))
 
@@ -37,33 +45,49 @@ class ZookeeperHasChildren(SimplePredicate):
         """
         :type event: kazoo.protocol.states.WatchedEvent or None
         """
-        exists = self.zkclient.exists(self.node, watch=self._watch_node)
-        if exists:
-            children = self.zkclient.get_children(self.node,
-                                                  watch=self._watch_node)
-            if self._ephemeral_only:
-                if children:
-                    for c in children:
-                        path = '/'.join([self.node, c])
-                        try:
-                            data, stat = self.zkclient.get(path)
-                            # we only care about ephemeral children
-                            if stat.ephemeralOwner != 0:
-                                self.set_met(True)
-                                break
-                        except NoNodeError:
-                            self._log.debug('Node does not exist: {0}'.format(path))
-                            continue
+        run_new_node_callback = False
+        try:
+            exists = self.zkclient.exists(self.node, watch=self._watch_node)
+            if exists:
+                children = self.zkclient.get_children(self.node,
+                                                      watch=self._watch_node)
+                if self._ephemeral_only:
+                    if children:
+                        for c in children:
+                            path = '/'.join([self.node, c])
+                            try:
+                                data, stat = self.zkclient.get(path)
+                                # we only care about ephemeral children
+                                if stat.ephemeralOwner != 0:
+                                    self.set_met(True)
+                                else:
+                                    self._log.info('New static node detected.')
+                                    run_new_node_callback = True
+
+                            except NoNodeError:
+                                self._log.debug('Node does not exist: {0}'.format(path))
+                                continue
+                    else:
+                        self.set_met(False)
                 else:
-                    self.set_met(False)
+                    # TODO: figure out if we need to change this logic for the new node callback
+                    self.set_met(bool(children))
+
+                # TODO: this is currently usused. to use it appropriately the logic
+                # in _update_children_list of zookeeperhasgrandchildren needs to change
+                if run_new_node_callback and self._nn_calback is not None:
+                    self._nn_calback()
             else:
-                self.set_met(bool(children))
+                self._handle_node_deletion()
+        except NoNodeError:
+            self._handle_node_deletion()
+
+    def _handle_node_deletion(self):
+        self._log.warning('Node {0} has been deleted.'.format(self.node))
+        if self._met_on_delete:
+            self.set_met(True)  # synthetically setting to true
         else:
-            self._log.warning('Node {0} has been deleted.'.format(self.node))
-            if self._met_on_delete:
-                self.set_met(True)  # synthetically setting to true
-            else:
-                self.set_met(False)
+            self.set_met(False)
 
     def __repr__(self):
         return ('{0}(component={1}, parent={2}, zkpath={3}, started={4}, '


### PR DESCRIPTION
The bug was that in `_update_children_list` the `new_nodes` (list of strings) was being compared against `self._children` (list of ZookeeperHasChildren objects). So any time something changed downstream of the nodepath the `_update_children_list` would create a new ZookeeperHasChildren regardless of whether it was already in `self._children`.

It seemed like that the old objects were still hanging around in memory b/c it would try to update the `met` value, but it wouldn't actually change the value for the object actually in `self._children`