### PR TITLE
Ensure child processes spawned by sentinel are able to generate core …

### DIFF
--- a/server/zoom/agent/entities/daemon.py
+++ b/server/zoom/agent/entities/daemon.py
@@ -1,6 +1,7 @@
 import logging
 import json
 import os
+import resource
 import signal
 import socket
 import sys
@@ -80,6 +81,10 @@ class SentinelDaemon(object):
 
     def __enter__(self):
         logging.info('Starting Sentinel, listening on port {}'.format(self._port))
+        try:
+            resource.setrlimit(resource.RLIMIT_CORE, (resource.RLIM_INFINITY, resource.RLIM_INFINITY))
+        except ValueError, ve:
+            logging.critical('Invalid resource limit specified. Core files will not be generated for apps: {0}'.format(ve))
         self._rest_server.listen(self._port)
         logging.info('Started Sentinel')
 


### PR DESCRIPTION
Child processes sometimes need to generate core files. This should probably be in a configuration option to enable/disable, and should likely be configurable/enable-able on a per-sentinel daemon config, however no such functionality currently exists and is not worth development time currently.